### PR TITLE
Add support for global decorators

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,75 @@ import testStorybookA11y from '@imaginelearning/test-storybook-a11y';
 testStorybookA11y('./**/*.stories.@(jsx|tsx)');
 ```
 
+### Additional parameters
+
+#### `GlobalStoryConfig`
+
+If your Storybook uses global decorators, you can provide a second parameter which a `GlobalStoryConfig` object:
+
+```ts
+interface GlobalStoryConfig {
+	decorators: StoryDecorator[];
+	globals: Args;
+}
+```
+
+The `decorators` property would typically be set with the decorators exported from your `preview.js` file.
+
+```ts
+// src/a11y.test.ts
+
+import testStorybookA11y from '@imaginelearning/test-storybook-a11y';
+import { decorators } from '../.storybook/preview';
+
+testStorybookA11y('./**/*.stories.@(jsx|tsx)', { decorators });
+```
+
+If your decorators make use of [`globalTypes`](https://storybook.js.org/docs/react/essentials/toolbars-and-globals#global-types-and-the-toolbar-annotation)
+those values can be included as well.
+
+```ts
+// src/a11y.test.ts
+
+import testStorybookA11y from '@imaginelearning/test-storybook-a11y';
+import { decorators } from '../.storybook/preview';
+
+testStorybookA11y('./**/*.stories.@(jsx|tsx)', {
+	decorators,
+	globals: { language: 'en' },
+});
+```
+
+#### `TestOptions`
+
+For more control over the test execution itself, you can provide an optional third parameter, which is a `TestOptions` object:
+
+```ts
+interface TestOptions {
+	timeout?: number;
+	axeOptions?: axe.RunOptions;
+}
+```
+
+The `timeout` property determines how long the test will wait for rendering to settle,
+using [DOM Testing Library's `waitFor` function](https://testing-library.com/docs/dom-testing-library/api-async/#waitfor).
+The default value is 1000 milliseconds.
+
+The `axeOptions` property is [`options` parameter](https://github.com/dequelabs/axe-core/blob/master/doc/API.md#options-parameter) passed directly to `axe-core`.
+
+```ts
+// src/a11y.test.ts
+
+import testStorybookA11y from '@imaginelearning/test-storybook-a11y';
+
+testStorybookA11y('./**/*.stories.@(jsx|tsx)', undefined, {
+	timeout: 5000,
+	axeOptions: {
+		runOnly: ['wcag2a', 'wcag2aa'],
+	},
+});
+```
+
 ## Disclaimer
 
 Using this package does not ensure comprehensive accessibility testing in your project.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,15 @@
+import { Args, Story, StoryContext } from '@storybook/react';
 import { axe } from 'jest-axe';
+import { FunctionComponentElement } from 'react';
+
+export interface StoryDecorator {
+	(story: Story, context?: Partial<StoryContext>): FunctionComponentElement;
+}
+
+export interface GlobalStoryConfig {
+	decorators: StoryDecorator[];
+	globals: Args;
+}
 
 export interface TestOptions {
 	timeout?: number;
@@ -9,10 +20,12 @@ export interface TestOptions {
  * Run axe accessibility tests with jest-axe on each Storybook story matching the specified glob pattern.
  *
  * @param storyGlob - Glob pattern for matching story files
+ * @param globalConfig - Global args to pass to each story
  * @param options - Options for setting test timeout and axe configuration
  */
 declare function testStorybookA11y(
 	storyGlob?: string = '**/*.stories.@(js|jsx|ts|tsx)',
+	globalConfig?: GlobalStoryConfig = {},
 	options: TestOptions = { timeout: 1000 }
 ): void;
 export default testStorybookA11y;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@imaginelearning/test-storybook-a11y",
-	"version": "0.1.3",
+	"version": "1.0.0",
 	"description": "Automatically run Jest accessibility tests on Storybook stories",
 	"keywords": [
 		"jest",


### PR DESCRIPTION
- Added optional parameter for passing global decorators and `globalTypes` to be included in rendering stories.
- Added documentation to README on additional parameters.